### PR TITLE
ci: fix Markdown lint

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -2,6 +2,9 @@
 MD004:
   style: dash
 
+MD013:
+  ignore_code_blocks: true
+
 # Ordered list item prefix
 MD029:
   style: one


### PR DESCRIPTION
It doesn't like the long line introduced in #33.