### PR TITLE
feat: add support for optional custom error messages by using ajv-errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,57 @@ jobs:
           files: .github/workflows/**.yml
 ```
 
+### Example with Custom Error Messages
+
+When `custom-errors` is enabled, you can use the `errorMessage` keyword in your
+JSON schema to provide more user-friendly error messages. This is powered by the
+[ajv-errors](https://github.com/ajv-validator/ajv-errors) library.
+
+```yaml
+jobs:
+  validate-config:
+    name: Validate configuration files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate config with custom errors
+        uses: dsanders11/json-schema-validate-action@v1.3.0
+        with:
+          schema: ./config.schema.json
+          files: ./config/*.yml
+          custom-errors: true
+```
+
+Example schema with custom error messages:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    }
+  },
+  "required": ["name", "version"],
+  "errorMessage": {
+    "type": "Configuration must be an object",
+    "required": {
+      "name": "Configuration must have a 'name' property",
+      "version": "Configuration must have a 'version' property"
+    },
+    "properties": {
+      "name": "Name must be a non-empty string",
+      "version": "Version must follow semantic versioning (e.g., '1.0.0')"
+    }
+  }
+}
+```
+
 ### Validating Schema
 
 Schemas can be validated by setting the `schema` input to the string literal
@@ -56,6 +107,8 @@ simply set a URL fragment (e.g. `#bust-cache`) on the schema URL.
   `true`)
 - `all-errors` - Whether to report all errors or stop after the first (default:
   `false`)
+- `custom-errors` - Enable support for custom error messages using ajv-errors
+  (default: `false`)
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: Report all errors instead of stopping at the first
     required: false
     default: false
+  custom-errors:
+    description: Enable support for custom error messages using ajv-errors
+    required: false
+    default: false
 
 outputs:
   valid:

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -952,6 +952,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+ajv-errors
+MIT
+MIT License
+
+Copyright (c) 2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 ajv-formats
 MIT
 MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@actions/http-client": "^2.2.0",
         "ajv": "^8.12.0",
         "ajv-draft-04": "^1.0.0",
+        "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "yaml": "^2.3.4"
       },
@@ -1944,6 +1945,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
       }
     },
     "node_modules/ajv-formats": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@actions/http-client": "^2.2.0",
     "ajv": "^8.12.0",
     "ajv-draft-04": "^1.0.0",
+    "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",
     "yaml": "^2.3.4"
   },


### PR DESCRIPTION
Some features of JSON schema validation such as `if-then-else` and `not` provide error messages that are quite difficult to understand without checking the schema definition. `ajv-errors` provides an easy way to workaround that by providing a keyword `errorMessage` which greatly extend how you can describe validation errors.

In this PR I added optional support for the use of  `ajv-errors` by using the input flag `custom-errors` in the input.