### PR TITLE
chore: run action on Node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ outputs:
     description: true if all files are valid, otherwise false
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "bundle": "npm run format:write && npm run package",


### PR DESCRIPTION
BREAKING CHANGE: This action now runs on node24

This isn't a true breaking change since it's really just bumping minimum Node.js version supported.